### PR TITLE
Upgrade Faraday to  2.9.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
 
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.2.3
 
 Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 3.2.3
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/lib/ngp_van.rb
+++ b/lib/ngp_van.rb
@@ -15,9 +15,9 @@ module NgpVan
     end
 
     # Delegate methods called on NgpVan to the client.
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, **args, &block)
       return super unless client.respond_to?(method_name)
-      client.send(method_name, *args, &block)
+      client.send(method_name, **args, &block)
     end
   end
 

--- a/lib/ngp_van/connection.rb
+++ b/lib/ngp_van/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ngp_van/response/raise_error'
-require 'faraday_middleware'
 
 module NgpVan
   module Connection
@@ -17,8 +16,8 @@ module NgpVan
         }
       }
 
-      Faraday::Connection.new(options) do |connection|
-        connection.request :basic_auth, config.application_name, config.api_key
+      Faraday.new(options) do |connection|
+        connection.request :authorization, :basic, config.application_name, config.api_key
 
         connection.request(:json)
         connection.use NgpVan::Response::RaiseError

--- a/lib/ngp_van/response/raise_error.rb
+++ b/lib/ngp_van/response/raise_error.rb
@@ -5,7 +5,7 @@ require 'faraday'
 
 module NgpVan
   module Response
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
       def on_complete(response)
         error = NgpVan::Error.from_response(response)
         raise error if error

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.name = 'ngp_van'
   spec.platform = Gem::Platform::RUBY
   spec.require_paths = %w(lib)
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 3.0.0'
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby wrapper for the NGP VAN API'
   spec.version = NgpVan::VERSION.dup
 
-  spec.add_dependency 'faraday', '>= 1.0.0', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.0'
+  spec.add_dependency 'faraday', '>= 2.0.1', '< 3.0'
 end

--- a/spec/ngp_van/client_spec.rb
+++ b/spec/ngp_van/client_spec.rb
@@ -87,5 +87,26 @@ module NgpVan
         end
       end
     end
+
+    describe '#get' do
+      let(:config) { NgpVan::Configuration.new }
+      let(:api_key) { 'test_key' }
+      let(:application_name) { 'test_app'}
+      subject { NgpVan::Client.new(config) }
+      let(:url) { build_url(client: subject, path: '/some/resource') }
+
+
+
+      before do
+        config.api_key = api_key
+        config.application_name =  application_name
+        stub_request(:get, url)
+      end
+
+      it 'makes a get request with basic auth headers' do
+        subject.get(path: '/some/resource')
+        expect(a_request(:get, url).with(basic_auth: [application_name, api_key])).to have_been_made
+      end
+    end
   end
 end


### PR DESCRIPTION
The Faraday middleware gem was deprecated in 2.0, but the JSON middleware moved inside of  Faraday, so no major changes needed.There were small updates to basic auth config and custom error handling as well.

All specs are now passing, I'm happy to run through any other checks etc. if needed