### PR TITLE
Add missing endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
 
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 3.2.3
 
 Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 
 rvm:
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 3.2.3
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/lib/ngp_van.rb
+++ b/lib/ngp_van.rb
@@ -15,9 +15,9 @@ module NgpVan
     end
 
     # Delegate methods called on NgpVan to the client.
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, **args, &block)
       return super unless client.respond_to?(method_name)
-      client.send(method_name, *args, &block)
+      client.send(method_name, **args, &block)
     end
   end
 

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -5,6 +5,7 @@ require 'ngp_van/request'
 require 'ngp_van/response'
 require 'ngp_van/client/activist_codes'
 require 'ngp_van/client/canvass_responses'
+require 'ngp_van/client/canvass_file_requests'
 require 'ngp_van/client/codes'
 require 'ngp_van/client/demographics'
 require 'ngp_van/client/district_fields'
@@ -54,6 +55,7 @@ module NgpVan
     include NgpVan::Response
     include NgpVan::Client::ActivistCodes
     include NgpVan::Client::CanvassResponses
+    include NgpVan::Client::CanvassFileRequests
     include NgpVan::Client::Codes
     include NgpVan::Client::Demographics
     include NgpVan::Client::DistrictFields

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -23,6 +23,7 @@ require 'ngp_van/client/signups'
 require 'ngp_van/client/stories'
 require 'ngp_van/client/survey_questions'
 require 'ngp_van/client/supporter_groups'
+require 'ngp_van/client/targets'
 require 'ngp_van/client/users'
 
 module NgpVan
@@ -70,6 +71,7 @@ module NgpVan
     include NgpVan::Client::Stories
     include NgpVan::Client::SupporterGroups
     include NgpVan::Client::SurveyQuestions
+    include NgpVan::Client::Targets
     include NgpVan::Client::Users
   end
 end

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -12,6 +12,7 @@ require 'ngp_van/client/echoes'
 require 'ngp_van/client/events'
 require 'ngp_van/client/event_types'
 require 'ngp_van/client/export_jobs'
+require 'ngp_van/client/folders'
 require 'ngp_van/client/locations'
 require 'ngp_van/client/notes'
 require 'ngp_van/client/people'
@@ -60,6 +61,7 @@ module NgpVan
     include NgpVan::Client::Events
     include NgpVan::Client::EventTypes
     include NgpVan::Client::ExportJobs
+    include NgpVan::Client::Folders
     include NgpVan::Client::Locations
     include NgpVan::Client::Notes
     include NgpVan::Client::People

--- a/lib/ngp_van/client/canvass_file_requests.rb
+++ b/lib/ngp_van/client/canvass_file_requests.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module CanvassFileRequests
+      def canvass_file_requests(body: {})
+        post(path: 'canvass_file_requests', body: body)
+      end
+
+      def canvass_file_request(id:)
+        verify_id(id)
+        get(path: "canvass_file_requests/#{id}")
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/folders.rb
+++ b/lib/ngp_van/client/folders.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Folders
+      def folders
+        get(path: 'folders')
+      end
+
+      def folder(id:, params: {})
+        verify_id(id)
+        get(path: "folders/#{id}", params: params)
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/saved_lists.rb
+++ b/lib/ngp_van/client/saved_lists.rb
@@ -11,6 +11,10 @@ module NgpVan
         verify_id(id)
         get(path: "savedLists/#{id}")
       end
+
+      def sms_sync(body: {})
+        post(path: "savedLists/smsSync", body: body)
+      end
     end
   end
 end

--- a/lib/ngp_van/client/targets.rb
+++ b/lib/ngp_van/client/targets.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Targets
+      def targets(params: {})
+        get(path: 'targets', params: params)
+      end
+
+      def target(id:, params: {})
+        verify_id(id)
+        get(path: "targets/#{id}", params: params)
+      end
+    end
+  end
+end

--- a/lib/ngp_van/connection.rb
+++ b/lib/ngp_van/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'ngp_van/response/raise_error'
-require 'faraday_middleware'
 
 module NgpVan
   module Connection
@@ -17,8 +16,8 @@ module NgpVan
         }
       }
 
-      Faraday::Connection.new(options) do |connection|
-        connection.request :basic_auth, config.application_name, config.api_key
+      Faraday.new(options) do |connection|
+        connection.request :authorization, :basic, config.application_name, config.api_key
 
         connection.request(:json)
         connection.use NgpVan::Response::RaiseError

--- a/lib/ngp_van/response/raise_error.rb
+++ b/lib/ngp_van/response/raise_error.rb
@@ -5,7 +5,7 @@ require 'faraday'
 
 module NgpVan
   module Response
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
       def on_complete(response)
         error = NgpVan::Error.from_response(response)
         raise error if error

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.name = 'ngp_van'
   spec.platform = Gem::Platform::RUBY
   spec.require_paths = %w(lib)
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 3.0.0'
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end

--- a/ngp_van.gemspec
+++ b/ngp_van.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.summary = 'Ruby wrapper for the NGP VAN API'
   spec.version = NgpVan::VERSION.dup
 
-  spec.add_dependency 'faraday', '>= 1.0.0', '< 2.0'
-  spec.add_dependency 'faraday_middleware', '>= 0.10.0'
+  spec.add_dependency 'faraday', '>= 2.0.1', '< 3.0'
 end

--- a/spec/ngp_van/client/canvass_file_requests_spec.rb
+++ b/spec/ngp_van/client/canvass_file_requests_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  # rubocop:disable Metrics/ClassLength
+  class Client
+    RSpec.describe CanvassFileRequests do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#canvass_file_requests' do
+        let(:response) { fixture('canvass_file_request.json') }
+        let(:url) { build_url(client: client, path: 'canvass_file_requests') }
+        let(:body) { { savedListId: 555888, webhookUrl: "https://webhook.example.org/canvassFileRequests", type:102 } }
+
+        before do
+          stub_request(:post, url)
+            .with(body: body)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.canvass_file_requests(body: body)
+          expect(
+            a_request(:post, url)
+          ).to have_been_made
+        end
+
+        it 'returns a hash of information' do
+          canvass_file_request = client.canvass_file_requests(body: body)
+          expect(canvass_file_request).to be_a(Hash)
+        end
+
+        it 'returns the status of the generated canvass file request' do
+          canvass_file_request = client.canvass_file_requests(body: body)
+          expect(canvass_file_request['status']).to eq('Completed')
+        end
+      end
+
+      describe '#canvass_file_request' do
+        let(:response) { fixture('canvass_file_request.json') }
+        let(:url) { build_url(client: client, path: 'canvass_file_requests/123') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.canvass_file_request(id: 123)
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns a canvass_file_request object' do
+          canvass_file_request = client.canvass_file_request(id: 123)
+          expect(canvass_file_request).to be_a(Hash)
+        end
+
+        it 'returns the requested canvass_file_request' do
+          canvass_file_request = client.canvass_file_request(id: 123)
+          expect(canvass_file_request['canvassFileRequestId']).to eq(123)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client/folders_spec.rb
+++ b/spec/ngp_van/client/folders_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  # rubocop:disable Metrics/ClassLength
+  class Client
+    RSpec.describe Folders do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#folders' do
+        let(:response) { fixture('folders.json') }
+        let(:url) { build_url(client: client, path: 'folders') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.folders
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns an array of items' do
+          folders = client.folders
+          expect(folders['items']).to be_a(Array)
+        end
+
+        it 'returns the requested folders' do
+          folders = client.folders
+          expect(folders['items'].first['folderId']).to eq(44)
+        end
+      end
+
+      describe '#folder' do
+        let(:params) { Hash.new }
+        let(:response) { fixture('folder.json') }
+        let(:url) { build_url(client: client, path: 'folders/44') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.folder(id: 44, params: params)
+          expect(
+            a_request(:get, url)
+              .with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns a folder object' do
+          folder = client.folder(id: 44, params: params)
+          expect(folder).to be_a(Hash)
+        end
+
+        it 'returns the requested folder' do
+          folder = client.folder(id: 44, params: params)
+          expect(folder['folderId']).to eq(44)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client/saved_lists_spec.rb
+++ b/spec/ngp_van/client/saved_lists_spec.rb
@@ -61,6 +61,26 @@ module NgpVan
           expect(saved_list['savedListId']).to eq(999888777)
         end
       end
+
+      describe '#sms_sync' do
+        let(:response) { fixture('sms_sync.json') }
+        let(:url) { build_url(client: client, path: 'savedLists/smsSync') }
+        let(:body) { { syncPeriodStart: "2016-05-23T18:00:00.0000000-04:00", syncPeriodEnd: "2016-05-24T18:00:00.0000000-04:00"} }
+
+        before do
+          stub_request(:post, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.sms_sync(body: body)
+          expect(a_request(:post, url).with(body: body)).to have_been_made
+        end
+
+        it 'returns a saved list ID' do
+          response = client.sms_sync(body: body)
+          expect(response['savedListId']).to eq 123
+        end
+      end
     end
   end
 end

--- a/spec/ngp_van/client/targets_spec.rb
+++ b/spec/ngp_van/client/targets_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  # rubocop:disable Metrics/ClassLength
+  class Client
+    RSpec.describe Targets do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#targets' do
+        let(:params) do
+          {
+            status: 'Setup',
+            type: 'Static',
+            top: 35,
+            expand: 'subgroups'
+          }
+        end
+        let(:response) { fixture('targets.json') }
+        let(:url) { build_url(client: client, path: 'targets') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.targets(params: params)
+          expect(
+            a_request(:get, url)
+              .with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns an array of items' do
+          targets = client.targets(params: params)
+          expect(targets['items']).to be_a(Array)
+        end
+
+        it 'returns the requested targets' do
+          targets = client.targets(params: params)
+          expect(targets['items'].first['targetId']).to eq(15880)
+        end
+      end
+
+      describe '#target' do
+        let(:params) { Hash.new }
+        let(:response) { fixture('target.json') }
+        let(:url) { build_url(client: client, path: 'targets/15880') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.target(id: 15880, params: params)
+          expect(
+            a_request(:get, url)
+              .with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns a target object' do
+          target = client.target(id: 15880, params: params)
+          expect(target).to be_a(Hash)
+        end
+
+        it 'returns the requested target' do
+          target = client.target(id: 15880, params: params)
+          expect(target['targetId']).to eq(15880)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client_spec.rb
+++ b/spec/ngp_van/client_spec.rb
@@ -87,5 +87,26 @@ module NgpVan
         end
       end
     end
+
+    describe '#get' do
+      let(:config) { NgpVan::Configuration.new }
+      let(:api_key) { 'test_key' }
+      let(:application_name) { 'test_app'}
+      subject { NgpVan::Client.new(config) }
+      let(:url) { build_url(client: subject, path: '/some/resource') }
+
+
+
+      before do
+        config.api_key = api_key
+        config.application_name =  application_name
+        stub_request(:get, url)
+      end
+
+      it 'makes a get request with basic auth headers' do
+        subject.get(path: '/some/resource')
+        expect(a_request(:get, url).with(basic_auth: [application_name, api_key])).to have_been_made
+      end
+    end
   end
 end

--- a/spec/support/fixtures/canvass_file_request.json
+++ b/spec/support/fixtures/canvass_file_request.json
@@ -1,0 +1,11 @@
+{
+  "canvassFileRequestId": 123,
+  "canvassFileRequestGuid": "DC7309A7-19F5-4DC7-8437-33FDBBADC2DA",
+  "savedListId": 555888,
+  "webhookUrl": "https://webhook.example.org/canvassFileRequests",
+  "downloadUrl": "https://vancanvassfiles.blob.core.windows.net/canvass-file/DC7309A7-2012-05-05T10:18:43.6007964-04:00.csv",
+  "status": "Completed",
+  "type": 102,
+  "dateExpired": "2012-05-05T12:18:43.6007964-04:00",
+  "errorCode": null
+}

--- a/spec/support/fixtures/folder.json
+++ b/spec/support/fixtures/folder.json
@@ -1,0 +1,4 @@
+{
+  "folderId":44,
+  "name":"API Generated Lists"
+}

--- a/spec/support/fixtures/folders.json
+++ b/spec/support/fixtures/folders.json
@@ -1,0 +1,14 @@
+{
+  "items":[
+    {
+      "folderId":44,
+      "name":"API Generated Lists"
+    },
+    {
+      "folderId":40,
+      "name":"Test Folder 6"
+    }
+  ],
+  "nextPageLink":null,
+  "count":2
+}

--- a/spec/support/fixtures/sms_sync.json
+++ b/spec/support/fixtures/sms_sync.json
@@ -1,0 +1,3 @@
+{
+  "savedListId": 123
+}

--- a/spec/support/fixtures/target.json
+++ b/spec/support/fixtures/target.json
@@ -1,0 +1,11 @@
+{
+  "targetId":15880,
+  "name":"API Demo Target",
+  "type":"Static",
+  "description":null,
+  "points":1,
+  "areSubgroupsSticky":false,
+  "status":"Setup",
+  "subgroups":[],
+  "markedSubgroup":null
+}

--- a/spec/support/fixtures/targets.json
+++ b/spec/support/fixtures/targets.json
@@ -1,0 +1,17 @@
+{
+  "items":[
+    {
+      "targetId": 15880,
+      "name":"API Demo Target",
+      "type": "Static",
+      "description": null,
+      "points": 1,
+      "areSubgroupsSticky": false,
+      "status": "Setup",
+      "subgroups": null,
+      "markedSubgroup": null
+    }
+  ],
+  "nextPageLink": null,
+  "count": 1
+}


### PR DESCRIPTION
NOTE: Depends on #1 , best to merge that before this.

Adding the following endpoints:

POST /savedLists/smsSync
https://docs.ngpvan.com/reference/smssync

Targets:
https://docs.ngpvan.com/reference/targets-overview
GET /targets
GET /targets/{targetId}

Folders:
https://docs.ngpvan.com/reference/folders-overview
GET /folders
GET /folders/{folderId}

Canvass File Requests
https://docs.ngpvan.com/reference/canvass-file-requests-overview
POST /canvassFileRequests
GET /canvassFileRequests/{canvassFileRequestId}


I've followed the existing conventions around fixtures and request body or params options.