### PR TITLE
Fix typo in canvass file request api

### DIFF
--- a/lib/ngp_van/client/canvass_file_requests.rb
+++ b/lib/ngp_van/client/canvass_file_requests.rb
@@ -4,12 +4,12 @@ module NgpVan
   class Client
     module CanvassFileRequests
       def canvass_file_requests(body: {})
-        post(path: 'canvass_file_requests', body: body)
+        post(path: 'canvassFileRequests', body: body)
       end
 
       def canvass_file_request(id:)
         verify_id(id)
-        get(path: "canvass_file_requests/#{id}")
+        get(path: "canvassFileRequests/#{id}")
       end
     end
   end

--- a/spec/ngp_van/client/canvass_file_requests_spec.rb
+++ b/spec/ngp_van/client/canvass_file_requests_spec.rb
@@ -9,7 +9,7 @@ module NgpVan
 
       describe '#canvass_file_requests' do
         let(:response) { fixture('canvass_file_request.json') }
-        let(:url) { build_url(client: client, path: 'canvass_file_requests') }
+        let(:url) { build_url(client: client, path: 'canvassFileRequests') }
         let(:body) { { savedListId: 555888, webhookUrl: 'https://webhook.example.org/canvassFileRequests', type: 102 } }
 
         before do
@@ -40,7 +40,7 @@ module NgpVan
 
       describe '#canvass_file_request' do
         let(:response) { fixture('canvass_file_request.json') }
-        let(:url) { build_url(client: client, path: 'canvass_file_requests/123') }
+        let(:url) { build_url(client: client, path: 'canvassFileRequests/123') }
 
         before do
           stub_request(:get, url)


### PR DESCRIPTION
Typo  in the original  implementation - the API uses camelCase, not snake_case.