### PR TITLE
Add Contributions, Disbursements, and ChangedEntityExportJobs endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 Style/Documentation:
   Enabled: false
 
-Style/FileName:
+Naming/FileName:
   Enabled: false
 
 Metrics/ClassLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [ADDED] Disbursements endpoints: `create_or_update_disbursement`, `disbursement`, and `recent_disbursements`.
 - [ADDED] Changed Entity Export Jobs endpoints: `changed_entity_resources`, `changed_entity_fields`, `create_changed_entity_export_job`, and `changed_entity_export_job`.
 - [ADDED] Optional per-request `headers` support to `post`/`put` requests.
+- [FIXED] `NgpVan::Error` no longer attempts to `JSON.parse` non-JSON error responses (e.g. an HTML 502 from an upstream proxy), which previously masked the real HTTP error with a `JSON::ParserError`. The body is now only parsed (and `errors` extracted) when the response `Content-Type` is JSON; otherwise the raw body is preserved on `error.body`. Ported from [controlshift/ngp_van](https://github.com/controlshift/ngp_van).
 
 # 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- [ADDED] Contributions endpoints (`create_contribution`, `contribution`, `contribution_by_type`, `contribution_attribution_types`, `create_or_update_contribution_attribution`, `delete_contribution_attribution`, `adjust_contribution`), ported from [controlshift/ngp_van](https://github.com/controlshift/ngp_van).
+- [ADDED] Designations endpoint (`designations`), ported from [controlshift/ngp_van](https://github.com/controlshift/ngp_van).
+- [ADDED] Additional Contributions endpoints: `create_contribution_payment` (`POST /contributions/payments`, with optional `Idempotency-Key` header) and `recent_contributions` (`GET /contributions/recentContributions`).
+- [ADDED] Disbursements endpoints: `create_or_update_disbursement`, `disbursement`, and `recent_disbursements`.
+- [ADDED] Changed Entity Export Jobs endpoints: `changed_entity_resources`, `changed_entity_fields`, `create_changed_entity_export_job`, and `changed_entity_export_job`.
+- [ADDED] Optional per-request `headers` support to `post`/`put` requests.
+
 # 0.11.0
 
 - [FIXED] Fix RaiseError middleware ([#42](https://github.com/christopherstyles/ngp_van/pull/42) by @lavaturtle).

--- a/lib/ngp_van/client.rb
+++ b/lib/ngp_van/client.rb
@@ -7,8 +7,12 @@ require 'ngp_van/client/activist_codes'
 require 'ngp_van/client/api_key_profiles'
 require 'ngp_van/client/canvass_responses'
 require 'ngp_van/client/canvass_file_requests'
+require 'ngp_van/client/changed_entity_export_jobs'
 require 'ngp_van/client/codes'
+require 'ngp_van/client/contributions'
 require 'ngp_van/client/demographics'
+require 'ngp_van/client/designations'
+require 'ngp_van/client/disbursements'
 require 'ngp_van/client/district_fields'
 require 'ngp_van/client/echoes'
 require 'ngp_van/client/events'
@@ -58,8 +62,12 @@ module NgpVan
     include NgpVan::Client::ApiKeyProfiles
     include NgpVan::Client::CanvassResponses
     include NgpVan::Client::CanvassFileRequests
+    include NgpVan::Client::ChangedEntityExportJobs
     include NgpVan::Client::Codes
+    include NgpVan::Client::Contributions
     include NgpVan::Client::Demographics
+    include NgpVan::Client::Designations
+    include NgpVan::Client::Disbursements
     include NgpVan::Client::DistrictFields
     include NgpVan::Client::Echoes
     include NgpVan::Client::Events

--- a/lib/ngp_van/client/changed_entity_export_jobs.rb
+++ b/lib/ngp_van/client/changed_entity_export_jobs.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module ChangedEntityExportJobs
+      def changed_entity_resources
+        get(path: 'changedEntityExportJobs/resources')
+      end
+
+      def changed_entity_fields(resource_type:)
+        verify_id(resource_type)
+        get(path: "changedEntityExportJobs/fields/#{resource_type}")
+      end
+
+      def create_changed_entity_export_job(body: {})
+        post(path: 'changedEntityExportJobs', body: body)
+      end
+
+      def changed_entity_export_job(id:)
+        verify_id(id)
+        get(path: "changedEntityExportJobs/#{id}")
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/contributions.rb
+++ b/lib/ngp_van/client/contributions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Contributions
+      def create_contribution(body: {})
+        post(path: 'contributions', body: body)
+      end
+
+      def create_contribution_payment(body: {}, idempotency_key: nil)
+        headers = idempotency_key ? { 'Idempotency-Key' => idempotency_key } : {}
+        post(path: 'contributions/payments', body: body, headers: headers)
+      end
+
+      def recent_contributions(params: {})
+        get(path: 'contributions/recentContributions', params: params)
+      end
+
+      def contribution(id:)
+        verify_id(id)
+        get(path: "contributions/#{id}")
+      end
+
+      def contribution_by_type(id:, type:)
+        verify_ids(id, type)
+        get(path: "contributions/#{type}:#{id}")
+      end
+
+      def contribution_attribution_types
+        get(path: 'contributions/attributionTypes')
+      end
+
+      def create_or_update_contribution_attribution(id:, van_id:, body: {})
+        verify_ids(id, van_id)
+        put(path: "contributions/#{id}/attributions/#{van_id}", body: body)
+      end
+
+      def delete_contribution_attribution(id:, van_id:)
+        verify_ids(id, van_id)
+        delete(path: "contributions/#{id}/attributions/#{van_id}")
+      end
+
+      def adjust_contribution(id:, body: {})
+        verify_ids(id)
+        post(path: "contributions/#{id}/adjustments", body: body)
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/designations.rb
+++ b/lib/ngp_van/client/designations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Designations
+      def designations
+        get(path: 'designations')
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/disbursements.rb
+++ b/lib/ngp_van/client/disbursements.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module NgpVan
+  class Client
+    module Disbursements
+      def create_or_update_disbursement(body: {})
+        post(path: 'disbursements', body: body)
+      end
+
+      def disbursement(id:)
+        verify_id(id)
+        get(path: "disbursements/#{id}")
+      end
+
+      def recent_disbursements(params: {})
+        get(path: 'disbursements/recentDisbursements', params: params)
+      end
+    end
+  end
+end

--- a/lib/ngp_van/client/phones.rb
+++ b/lib/ngp_van/client/phones.rb
@@ -3,7 +3,7 @@
 module NgpVan
   class Client
     module Phones
-      def is_cell_statuses # rubocop:disable Naming/PredicateName
+      def is_cell_statuses # rubocop:disable Naming/PredicatePrefix
         get(path: 'phones/isCellStatuses')
       end
     end

--- a/lib/ngp_van/error.rb
+++ b/lib/ngp_van/error.rb
@@ -45,14 +45,28 @@ module NgpVan
 
     def initialize(response = nil)
       @response = response
-      @body = ::JSON.parse(response[:body])
+      if json_response?(response)
+        @body = ::JSON.parse(response[:body])
+        @errors = body.delete('errors')
+      else
+        @body = response[:body]
+      end
       @status = response[:status]
-      @errors = body.delete('errors')
 
       super(build_error)
     end
 
     private
+
+    # The API normally returns JSON error payloads, but infrastructure in
+    # front of it (proxies, load balancers, CDNs) can return non-JSON bodies
+    # such as an HTML 502 page. Only parse the body as JSON when the response
+    # actually advertises it, otherwise JSON parsing would mask the real
+    # HTTP error with a JSON::ParserError.
+    def json_response?(response)
+      content_type = response.response_headers&.[]('Content-Type')
+      content_type&.match?(%r{application/json}i) || false
+    end
 
     def build_error
       return nil if response.nil?

--- a/lib/ngp_van/request.rb
+++ b/lib/ngp_van/request.rb
@@ -15,21 +15,22 @@ module NgpVan
     end
 
     # Perform an HTTP POST request
-    def post(path:, body: {})
-      request(method: :post, path: path, body: body)
+    def post(path:, body: {}, headers: {})
+      request(method: :post, path: path, body: body, headers: headers)
     end
 
     # Perform an HTTP PUT request
-    def put(path:, body: {})
-      request(method: :put, path: path, body: body)
+    def put(path:, body: {}, headers: {})
+      request(method: :put, path: path, body: body, headers: headers)
     end
 
     private
 
-    def request(method:, path:, params: {}, body: {})
+    def request(method:, path:, params: {}, body: {}, headers: {})
       response = connection.send(method) do |request|
         request.path = path
         request.params = params
+        request.headers.update(headers) unless headers.empty?
         request.body = ::JSON.generate(body) unless body.empty?
       end
 

--- a/spec/ngp_van/client/changed_entity_export_jobs_spec.rb
+++ b/spec/ngp_van/client/changed_entity_export_jobs_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  class Client
+    RSpec.describe ChangedEntityExportJobs do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#changed_entity_resources' do
+        let(:response) { fixture('changed_entity_resources.json') }
+        let(:url) { build_url(client: client, path: 'changedEntityExportJobs/resources') }
+
+        before do
+          stub_request(:get, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.changed_entity_resources
+          expect(a_request(:get, url)).to have_been_made
+        end
+
+        it 'returns an array of resource types' do
+          resources = client.changed_entity_resources
+          expect(resources).to be_a(Array)
+        end
+      end
+
+      describe '#changed_entity_fields' do
+        let(:response) { fixture('changed_entity_fields.json') }
+        let(:url) do
+          build_url(client: client, path: 'changedEntityExportJobs/fields/Contributions')
+        end
+
+        before do
+          stub_request(:get, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.changed_entity_fields(resource_type: 'Contributions')
+          expect(a_request(:get, url)).to have_been_made
+        end
+
+        it 'returns an array of field definitions' do
+          fields = client.changed_entity_fields(resource_type: 'Contributions')
+          expect(fields).to be_a(Array)
+        end
+      end
+
+      describe '#create_changed_entity_export_job' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/create_changed_entity_export_job.json"))
+        end
+
+        let(:response) { fixture('changed_entity_export_job.json') }
+        let(:url) { build_url(client: client, path: 'changedEntityExportJobs') }
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              status: 201,
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_changed_entity_export_job(body: body)
+          expect(
+            a_request(:post, url).with(body: body)
+          ).to have_been_made
+        end
+
+        it 'returns the export job' do
+          job = client.create_changed_entity_export_job(body: body)
+          expect(job['exportJobId']).to eq(555444333)
+        end
+      end
+
+      describe '#changed_entity_export_job' do
+        let(:response) { fixture('changed_entity_export_job.json') }
+        let(:url) { build_url(client: client, path: 'changedEntityExportJobs/555444333') }
+
+        before do
+          stub_request(:get, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.changed_entity_export_job(id: 555444333)
+          expect(a_request(:get, url)).to have_been_made
+        end
+
+        it 'returns the requested export job' do
+          job = client.changed_entity_export_job(id: 555444333)
+          expect(job['exportJobId']).to eq(555444333)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client/contributions_spec.rb
+++ b/spec/ngp_van/client/contributions_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  class Client
+    RSpec.describe Contributions do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#create_contribution' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/create_contribution.json"))
+        end
+
+        let(:response) { fixture('create_contribution_response.json') }
+        let(:url) { build_url(client: client, path: 'contributions') }
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              status: 201,
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_contribution(body: body)
+          expect(
+            a_request(:post, url)
+              .with(
+                body: body
+              )
+          ).to have_been_made
+        end
+
+        it 'returns the created id' do
+          contrib = client.create_contribution(body: body)
+          expect(contrib['contributionId']).to eq(1234567890)
+        end
+      end
+
+      describe '#create_contribution_payment' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/create_contribution.json"))
+        end
+
+        let(:url) { build_url(client: client, path: 'contributions/payments') }
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              status: 201,
+              body: '1234567890'
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_contribution_payment(body: body)
+          expect(
+            a_request(:post, url)
+              .with(body: body)
+          ).to have_been_made
+        end
+
+        it 'sends the idempotency key header when provided' do
+          client.create_contribution_payment(body: body, idempotency_key: 'abc-123')
+          expect(
+            a_request(:post, url)
+              .with(headers: { 'Idempotency-Key' => 'abc-123' })
+          ).to have_been_made
+        end
+
+        it 'returns the created id' do
+          expect(client.create_contribution_payment(body: body)).to eq(1234567890)
+        end
+      end
+
+      describe '#recent_contributions' do
+        let(:response) { fixture('recent_contributions.json') }
+        let(:params) { { van_id: 215501 } }
+        let(:url) { build_url(client: client, path: 'contributions/recentContributions') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.recent_contributions(params: params)
+          expect(
+            a_request(:get, url).with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns a list of contributions' do
+          contributions = client.recent_contributions(params: params)
+          expect(contributions['items']).to be_a(Array)
+        end
+      end
+
+      describe '#person' do
+        let(:response) { fixture('contribution.json') }
+        let(:url) { build_url(client: client, path: 'contributions/1234567890') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.contribution(id: 1234567890)
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns a person object' do
+          contrib = client.contribution(id: 1234567890)
+          expect(contrib).to be_a(Hash)
+        end
+
+        it 'returns the requested contribution' do
+          contrib = client.contribution(id: 1234567890)
+          expect(contrib['contributionId']).to eq(1234567890)
+        end
+      end
+
+      describe '#contribution_by_type' do
+        let(:response) { fixture('contribution.json') }
+        let(:url) { build_url(client: client, path: 'contributions/onlineReferenceNumber:1230230423') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.contribution_by_type(id: 1230230423, type: 'onlineReferenceNumber')
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns a contribution object' do
+          contrib = client.contribution_by_type(id: 1230230423, type: 'onlineReferenceNumber')
+          expect(contrib).to be_a(Hash)
+        end
+
+        it 'returns the requested contribution' do
+          contrib = client.contribution_by_type(id: 1230230423, type: 'onlineReferenceNumber')
+          expect(contrib['onlineReferenceNumber']).to eq('1230230423')
+        end
+      end
+
+      describe '#contribution_attribution_types' do
+        let(:response) { fixture('contribution_attribution_types.json') }
+        let(:url) { build_url(client: client, path: 'contributions/attributionTypes') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.contribution_attribution_types
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns a list of objects' do
+          attrib_types = client.contribution_attribution_types
+          expect(attrib_types['attributionTypes']).to be_a(Array)
+        end
+      end
+
+      describe '#create_or_update_contribution_attribution' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/attribution.json"))
+        end
+
+        let(:url) do
+          build_url(client: client, path: 'contributions/1234567890/attributions/215501')
+        end
+
+        before do
+          stub_request(:put, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              body: '',
+              status: 204
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_or_update_contribution_attribution(id: 1234567890, van_id: 215501, body: body)
+          expect(
+            a_request(:put, url)
+              .with(body: JSON.generate(body))
+          ).to have_been_made
+        end
+
+        it 'returns an empty response body' do
+          expect(
+            client.create_or_update_contribution_attribution(id: 1234567890, van_id: 215501, body: body)
+          ).to eq('')
+        end
+      end
+
+      describe '#delete_contribution_attribution' do
+        let(:url) do
+          build_url(client: client, path: 'contributions/1234567890/attributions/215501')
+        end
+
+        before do
+          stub_request(:delete, url)
+            .to_return(
+              body: '',
+              status: 204
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.delete_contribution_attribution(id: 1234567890, van_id: 215501)
+          expect(
+            a_request(:delete, url)
+          ).to have_been_made
+        end
+
+        it 'returns an empty response body' do
+          expect(
+            client.delete_contribution_attribution(id: 1234567890, van_id: 215501)
+          ).to eq('')
+        end
+      end
+
+      describe '#adjust_contribution' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/contribution_adjustment.json"))
+        end
+        let(:response_body) do
+          File.read("#{fixture_path}/contribution_adjustment_response.json")
+        end
+
+        let(:url) do
+          build_url(client: client, path: 'contributions/1234567890/adjustments')
+        end
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              body: response_body,
+              status: 200
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.adjust_contribution(id: 1234567890, body: body)
+          expect(
+            a_request(:post, url)
+              .with(body: JSON.generate(body))
+          ).to have_been_made
+        end
+
+        it 'returns the response object' do
+          expect(
+            client.adjust_contribution(id: 1234567890, body: body)
+          ).to eq(JSON.parse(response_body))
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client/designations_spec.rb
+++ b/spec/ngp_van/client/designations_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  class Client
+    RSpec.describe Designations do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#designations' do
+        let(:response) { fixture('designations.json') }
+        let(:url) { build_url(client: client, path: 'designations') }
+
+        before do
+          stub_request(:get, url)
+            .to_return(
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.designations
+          expect(
+            a_request(:get, url)
+          ).to have_been_made
+        end
+
+        it 'returns an array of items' do
+          designations = client.designations
+          expect(designations['items']).to be_a(Array)
+        end
+
+        it 'returns the requested designations' do
+          designations = client.designations
+          expect(designations['items'].first['designationId']).to eq(123456789)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/client/disbursements_spec.rb
+++ b/spec/ngp_van/client/disbursements_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module NgpVan
+  class Client
+    RSpec.describe Disbursements do
+      let(:client) { NgpVan::Client.new }
+
+      describe '#create_or_update_disbursement' do
+        let(:body) do
+          JSON.parse(File.read("#{fixture_path}/create_disbursement.json"))
+        end
+
+        let(:response) { fixture('disbursement.json') }
+        let(:url) { build_url(client: client, path: 'disbursements') }
+
+        before do
+          stub_request(:post, url)
+            .with(body: JSON.generate(body))
+            .to_return(
+              status: 201,
+              body: response
+            )
+        end
+
+        it 'requests the correct resource' do
+          client.create_or_update_disbursement(body: body)
+          expect(
+            a_request(:post, url).with(body: body)
+          ).to have_been_made
+        end
+
+        it 'returns the disbursement' do
+          disbursement = client.create_or_update_disbursement(body: body)
+          expect(disbursement['disbursementId']).to eq(987654321)
+        end
+      end
+
+      describe '#disbursement' do
+        let(:response) { fixture('disbursement.json') }
+        let(:url) { build_url(client: client, path: 'disbursements/987654321') }
+
+        before do
+          stub_request(:get, url).to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.disbursement(id: 987654321)
+          expect(a_request(:get, url)).to have_been_made
+        end
+
+        it 'returns a disbursement object' do
+          disbursement = client.disbursement(id: 987654321)
+          expect(disbursement).to be_a(Hash)
+        end
+
+        it 'returns the requested disbursement' do
+          disbursement = client.disbursement(id: 987654321)
+          expect(disbursement['disbursementId']).to eq(987654321)
+        end
+      end
+
+      describe '#recent_disbursements' do
+        let(:response) { fixture('recent_disbursements.json') }
+        let(:params) { { vanId: 215501 } }
+        let(:url) { build_url(client: client, path: 'disbursements/recentDisbursements') }
+
+        before do
+          stub_request(:get, url)
+            .with(query: params)
+            .to_return(body: response)
+        end
+
+        it 'requests the correct resource' do
+          client.recent_disbursements(params: params)
+          expect(
+            a_request(:get, url).with(query: params)
+          ).to have_been_made
+        end
+
+        it 'returns a list of disbursements' do
+          disbursements = client.recent_disbursements(params: params)
+          expect(disbursements['items']).to be_a(Array)
+        end
+      end
+    end
+  end
+end

--- a/spec/ngp_van/request_spec.rb
+++ b/spec/ngp_van/request_spec.rb
@@ -69,13 +69,49 @@ module NgpVan
         end
 
         before do
-          stub_request(:get, url).to_return(status: 404, body: response_body)
+          stub_request(:get, url).to_return(
+            status: 404,
+            headers: { 'Content-Type' => 'application/json' },
+            body: response_body
+          )
         end
 
         it 'raises an appropriate error' do
-          expect do
-            NgpVan.get(path: '/some/resource')
-          end.to raise_error(NgpVan::NotFound)
+          expect { NgpVan.get(path: '/some/resource') }
+            .to raise_error(NgpVan::NotFound) do |error|
+              expect(error.errors&.count).to eq(1)
+              expect(error.errors[0]['code']).to eq('NOT_FOUND')
+              expect(error.errors[0]['text']).to eq('it was not found')
+            end
+        end
+      end
+
+      context 'when the response is not in JSON format' do
+        let(:response_body) do
+          <<-HTML
+            <html class="no-js" lang="en-US">
+              <head><title>502 Bad Gateway</title></head>
+              <body>
+                <span>Error code 502</span>
+              </body>
+            </html>
+          HTML
+        end
+
+        before do
+          stub_request(:get, url).to_return(
+            status: 502,
+            headers: { 'Content-Type' => 'text/html' },
+            body: response_body
+          )
+        end
+
+        it 'raises an appropriate error without attempting to parse the body' do
+          expect { NgpVan.get(path: '/some/resource') }
+            .to raise_error(NgpVan::BadGateway) do |error|
+              expect(error.body).to eq(response_body)
+              expect(error.errors).to be_nil
+            end
         end
       end
     end

--- a/spec/support/fixtures/attribution.json
+++ b/spec/support/fixtures/attribution.json
@@ -1,0 +1,7 @@
+{
+  "vanId": 215501,
+  "amountAttributed": 100.00,
+  "attributionType": "BoardMemberGiving",
+  "dateThanked": "2019-10-08",
+  "notes": "This will be created or updated"
+}

--- a/spec/support/fixtures/changed_entity_export_job.json
+++ b/spec/support/fixtures/changed_entity_export_job.json
@@ -1,0 +1,15 @@
+{
+  "exportJobId": 555444333,
+  "dateChangedFrom": "2026-06-01T00:00:00Z",
+  "dateChangedTo": "2026-06-30T00:00:00Z",
+  "files": [
+    {
+      "downloadUrl": "https://ngpvan.blob.core.windows.net/changedentities/555444333.csv",
+      "dateExpired": "2026-07-06T00:00:00Z"
+    }
+  ],
+  "jobStatus": "Complete",
+  "message": null,
+  "code": null,
+  "exportedRecordCount": 42
+}

--- a/spec/support/fixtures/changed_entity_fields.json
+++ b/spec/support/fixtures/changed_entity_fields.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "VanID",
+    "type": "N",
+    "maxTextboxCharacters": null,
+    "isCoreField": true,
+    "availableValues": null
+  },
+  {
+    "name": "ContributionID",
+    "type": "N",
+    "maxTextboxCharacters": null,
+    "isCoreField": true,
+    "availableValues": null
+  }
+]

--- a/spec/support/fixtures/changed_entity_resources.json
+++ b/spec/support/fixtures/changed_entity_resources.json
@@ -1,0 +1,7 @@
+[
+  "ContactHistory",
+  "Contacts",
+  "ContactsActivistCodes",
+  "Contributions",
+  "Disbursements"
+]

--- a/spec/support/fixtures/contribution.json
+++ b/spec/support/fixtures/contribution.json
@@ -1,0 +1,84 @@
+{
+    "contributionId": 1234567890,
+    "contact": {
+        "vanId": 10005165
+    },
+    "designation": {
+        "designationId": 18754
+    },
+    "dateReceived": "2013-12-25T12:23:00Z",
+    "amount": "12.34",
+    "coverCostsAmount": "2.34",
+    "status": "Settled",
+    "paymentType": "Check",
+    "bankAccount": "PNC Bank Account 1",
+    "contributionBankAccount": {
+        "bankAccountId": 9876,
+        "name": "PNC Bank Account 1"
+    },
+    "depositDate": "2013-12-28",
+    "depositNumber": 3,
+    "checkDate": "2013-12-25",
+    "checkNumber": "1222 123",
+    "contactAttributions": [
+        {
+          "vanId": 303,
+          "amountAttributed": "100.50",
+          "attributionType": "DefaultAttribution",
+          "notes": "some notes go here",
+          "dateThanked": "2013-12-30"
+        },
+        {
+          "vanId": 701,
+          "amountAttributed": "202.10",
+          "attributionType": "CorporateMatch",
+          "notes": "some notes go here",
+          "dateThanked": "2013-12-30"
+        }
+    ],
+    "onlineReferenceNumber": "1230230423",
+    "pledge": {
+        "pledgeId": 1035
+    },
+    "codes": [
+        { "codeId": 12345, "codeName": "Signup Form Source Code" }
+    ],
+    "directMarketingCode": "Excelsior Consulting",
+    "dateThanked": "2013-12-30",
+    "notes": "Processed as part of the Christmas Fundraiser",
+    "disclosureFieldValues": [
+        {
+          "disclosureFieldId": 190,
+          "disclosureFieldValue": "41",
+          "designationId": 1121
+        },
+        {
+          "disclosureFieldId": 40,
+          "disclosureFieldValue": "5",
+          "designationId": 1121
+        },
+        {
+          "disclosureFieldId": 1001,
+          "disclosureFieldValue": "John",
+          "designationId": 1121
+        }
+    ],
+    "extendedSourceCode" : {
+      "extendedSourceCodeId": 12
+    },
+    "identifiers": [
+        {
+          "type": "ActBlue ID",
+          "externalId": "123456"
+        }
+    ],
+    "financialBatchId": 825,
+    "processedAmount": 3,
+    "processedCurrency": "USD",
+    "acceptedOneTimeAmount": "12.34",
+    "acceptedRecurringAmount": "5.67",
+    "selectedOneTimeAmount": "20.00",
+    "upsellType": "Split",
+    "isUpsellShown": true,
+    "isUpsellAccepted": true
+}

--- a/spec/support/fixtures/contribution_adjustment.json
+++ b/spec/support/fixtures/contribution_adjustment.json
@@ -1,0 +1,5 @@
+{
+  "adjustmentType" : "Refund",
+  "amount" : 10.0,
+  "datePosted" : "2020-03-31"
+}

--- a/spec/support/fixtures/contribution_adjustment_response.json
+++ b/spec/support/fixtures/contribution_adjustment_response.json
@@ -1,0 +1,6 @@
+{
+  "contributionId" : 123,
+  "originalAmount" : 20.00,
+  "remainingAmount" : 10.00,
+  "dateAdjusted": "2020-03-04"
+}

--- a/spec/support/fixtures/contribution_attribution_types.json
+++ b/spec/support/fixtures/contribution_attribution_types.json
@@ -1,0 +1,16 @@
+{
+  "attributionTypes": [
+    "BoardMemberGiving",
+    "CorporateMatch",
+    "DefaultAttribution",
+    "DonorAdvisedFund",
+    "DonorMatch",
+    "FamilyPrivateFoundation",
+    "FinanceCommittee",
+    "GiftMembership",
+    "RaisedContribution",
+    "TributeGift",
+    "TallyMember",
+    "WorkplaceGiving"
+  ]
+}

--- a/spec/support/fixtures/create_changed_entity_export_job.json
+++ b/spec/support/fixtures/create_changed_entity_export_job.json
@@ -1,0 +1,12 @@
+{
+  "dateChangedFrom": "2026-06-01T00:00:00.00Z",
+  "dateChangedTo": "2026-06-30T00:00:00.00Z",
+  "resourceType": "Contributions",
+  "requestedFields": [
+    "ContributionID",
+    "VanID",
+    "Amount"
+  ],
+  "fileSizeKbLimit": 25000,
+  "includeInactive": false
+}

--- a/spec/support/fixtures/create_contribution.json
+++ b/spec/support/fixtures/create_contribution.json
@@ -1,0 +1,83 @@
+{
+    "contact": {
+        "vanId": 10005165
+    },
+    "designation": {
+        "designationId": 18754
+    },
+    "dateReceived": "2013-12-25T12:23:00Z",
+    "amount": "12.34",
+    "coverCostsAmount": "2.34",
+    "status": "Settled",
+    "paymentType": "Check",
+    "bankAccount": "PNC Bank Account 1",
+    "contributionBankAccount": {
+        "bankAccountId": 9876,
+        "name": "PNC Bank Account 1"
+    },
+    "depositDate": "2013-12-28",
+    "depositNumber": 3,
+    "checkDate": "2013-12-25",
+    "checkNumber": "1222 123",
+    "contactAttributions": [
+        {
+          "vanId": 303,
+          "amountAttributed": "100.50",
+          "attributionType": "DefaultAttribution",
+          "notes": "some notes go here",
+          "dateThanked": "2013-12-30"
+        },
+        {
+          "vanId": 701,
+          "amountAttributed": "202.10",
+          "attributionType": "CorporateMatch",
+          "notes": "some notes go here",
+          "dateThanked": "2013-12-30"
+        }
+    ],
+    "onlineReferenceNumber": "1230230423",
+    "pledge": {
+        "pledgeId": 1035
+    },
+    "codes": [
+        { "codeId": 12345, "codeName": "Signup Form Source Code" }
+    ],
+    "directMarketingCode": "Excelsior Consulting",
+    "dateThanked": "2013-12-30",
+    "notes": "Processed as part of the Christmas Fundraiser",
+    "disclosureFieldValues": [
+        {
+          "disclosureFieldId": 190,
+          "disclosureFieldValue": "41",
+          "designationId": 1121
+        },
+        {
+          "disclosureFieldId": 40,
+          "disclosureFieldValue": "5",
+          "designationId": 1121
+        },
+        {
+          "disclosureFieldId": 1001,
+          "disclosureFieldValue": "John",
+          "designationId": 1121
+        }
+    ],
+    "extendedSourceCode" : {
+      "extendedSourceCodeId": 12
+    },
+    "identifiers": [
+        {
+          "type": "ActBlue ID",
+          "externalId": "123456"
+        }
+    ],
+    "financialBatchId": 825,
+    "processedAmount": 3,
+    "processedCurrency": "USD",
+    "acceptedOneTimeAmount": "12.34",
+    "acceptedRecurringAmount": "5.67",
+    "selectedOneTimeAmount": "20.00",
+    "upsellType": "Split",
+    "isUpsellShown": true,
+    "isUpsellAccepted": true
+}

--- a/spec/support/fixtures/create_contribution_response.json
+++ b/spec/support/fixtures/create_contribution_response.json
@@ -1,0 +1,3 @@
+{
+  "contributionId": 1234567890
+}

--- a/spec/support/fixtures/create_disbursement.json
+++ b/spec/support/fixtures/create_disbursement.json
@@ -1,0 +1,10 @@
+{
+  "amount": 150.5,
+  "dateIssued": "2026-05-15T00:00:00Z",
+  "designationId": 12,
+  "contact": {
+    "vanId": 215501
+  },
+  "checkNumber": "1043",
+  "checkDate": "2026-05-15T00:00:00Z"
+}

--- a/spec/support/fixtures/designations.json
+++ b/spec/support/fixtures/designations.json
@@ -1,0 +1,12 @@
+{
+  "items" : [
+    {
+      "designationId": 123456789,
+      "name": "Jane for Congress Committee"
+    },
+    {
+      "designationId": 123456790,
+      "name": "Jane Smith Progressive Leadership PAC"
+    }
+  ]
+}

--- a/spec/support/fixtures/disbursement.json
+++ b/spec/support/fixtures/disbursement.json
@@ -1,0 +1,14 @@
+{
+  "disbursementId": 987654321,
+  "amount": 150.5,
+  "dateIssued": "2026-05-15T00:00:00Z",
+  "designation": {
+    "designationId": 12,
+    "name": "General"
+  },
+  "contact": {
+    "vanId": 215501
+  },
+  "checkNumber": "1043",
+  "checkDate": "2026-05-15T00:00:00Z"
+}

--- a/spec/support/fixtures/recent_contributions.json
+++ b/spec/support/fixtures/recent_contributions.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "contributionId": 1234567890,
+      "vanId": 215501,
+      "amount": 25.0,
+      "dateReceived": "2026-06-01T00:00:00Z",
+      "designation": {
+        "designationId": 12,
+        "name": "General"
+      }
+    }
+  ],
+  "count": 1,
+  "nextPageLink": null
+}

--- a/spec/support/fixtures/recent_disbursements.json
+++ b/spec/support/fixtures/recent_disbursements.json
@@ -1,0 +1,15 @@
+{
+  "items": [
+    {
+      "disbursementId": 987654321,
+      "amount": 150.5,
+      "dateIssued": "2026-05-15T00:00:00Z",
+      "designation": {
+        "designationId": 12,
+        "name": "General"
+      }
+    }
+  ],
+  "count": 1,
+  "nextPageLink": null
+}


### PR DESCRIPTION
This PR adds support for three new API endpoint modules to the NGP VAN client library, ported from the controlshift/ngp_van repository.

## Summary
Adds comprehensive support for managing contributions, disbursements, and changed entity export jobs through the NGP VAN API, including full test coverage and fixture data.

## Key Changes

**New Endpoint Modules:**
- `Contributions` module with 8 methods:
  - `create_contribution` - Create a new contribution
  - `create_contribution_payment` - Create a contribution payment with optional idempotency key support
  - `recent_contributions` - Retrieve recent contributions for a contact
  - `contribution` - Get a specific contribution by ID
  - `contribution_by_type` - Get a contribution by alternate identifier types
  - `contribution_attribution_types` - List available attribution types
  - `create_or_update_contribution_attribution` - Manage contribution attributions
  - `delete_contribution_attribution` - Remove a contribution attribution
  - `adjust_contribution` - Adjust a contribution amount

- `Disbursements` module with 3 methods:
  - `create_or_update_disbursement` - Create or update a disbursement
  - `disbursement` - Get a specific disbursement by ID
  - `recent_disbursements` - Retrieve recent disbursements

- `Designations` module with 1 method:
  - `designations` - List all designations

- `ChangedEntityExportJobs` module with 4 methods:
  - `changed_entity_resources` - List available resource types for export
  - `changed_entity_fields` - Get available fields for a resource type
  - `create_changed_entity_export_job` - Create an export job
  - `changed_entity_export_job` - Get export job status and details

**Error Handling Improvements:**
- Enhanced error handling in `NgpVan::Error` to gracefully handle non-JSON responses (e.g., HTML error pages from infrastructure)
- Only attempts JSON parsing when response Content-Type indicates JSON

**Request Method Updates:**
- Added optional `headers` parameter to `post` and `put` methods to support custom headers like `Idempotency-Key`

**Test Coverage:**
- Comprehensive RSpec test suites for all new modules with fixture data
- Tests verify correct resource requests, response parsing, and error handling

**Code Quality:**
- Updated RuboCop configuration to use `Naming/FileName` instead of deprecated `Style/FileName`
- Fixed RuboCop directive in phones.rb from `Naming/PredicateName` to `Naming/PredicatePrefix`

## Notable Implementation Details
- The `create_contribution_payment` method supports idempotency keys for safe retries
- Error responses are now safely handled whether they're JSON or HTML (e.g., 502 Bad Gateway pages)
- All modules follow the existing client pattern with proper ID verification

https://claude.ai/code/session_01AGGv8dbpxu8ovzypJRgYPf